### PR TITLE
Fix json file not exist error

### DIFF
--- a/.github/workflows/actionsflow.yml
+++ b/.github/workflows/actionsflow.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Setup act
         uses: actionsflow/setup-act-for-actionsflow@v1
       - name: Run act
-        run: act --workflows ./dist/workflows --secret-file ./dist/.secrets --eventpath ./dist/event.json --env-file ./dist/.env -P ubuntu-latest=actionsflow/act-environment:v1 -P ubuntu-18.04=actionsflow/act-environment:v1
+        run: act --workflows ./dist/workflows --secret-file ./dist/.secrets --eventpath ./dist/event.json --env-file ./dist/.env -P ubuntu-latest=actionsflow/act-environment:v1 -P ubuntu-18.04=actionsflow/act-environment:v1 --bind

--- a/workflows/rss.yml
+++ b/workflows/rss.yml
@@ -1,6 +1,8 @@
 on:
   rss:
     url: https://hnrss.org/newest?points=300&count=10
+    config:
+      active: false
 jobs:
   print:
     name: Print


### PR DESCRIPTION
Hi, I found the error reason. By the doc https://actionsflow.github.io/docs/workflow/#ontriggerconfigexportoutputs

if we use `exportOutputs`, we should bind the host files to docker container.

Now it's ok!